### PR TITLE
[UPDATE] Made LSTM layers capable of taking in variable length inputs

### DIFF
--- a/datasets/dataframes.go
+++ b/datasets/dataframes.go
@@ -490,8 +490,8 @@ func (frame *DataFrame) ToDataset(inputSlice string, outputSlice string) []DataP
 func (frame *DataFrame) ToSequentialDataset(inputSlice string, outputSlice string, intervalLength int) []DataPoint {
 	isInput, isOutput := utils.ParseSlice(inputSlice), utils.ParseSlice(outputSlice)
 
-	dataset := make([]DataPoint, len(frame.values))
-	for i := range frame.values[:len(frame.values)-intervalLength-1] {
+	dataset := make([]DataPoint, len(frame.values)-intervalLength)
+	for i := range frame.values[:len(frame.values)-intervalLength] {
 		nextRow := frame.values[i+1]
 		input, output := make([]float64, 0), make([]float64, 0)
 		for _, row := range frame.values[i : i+intervalLength] {
@@ -506,7 +506,6 @@ func (frame *DataFrame) ToSequentialDataset(inputSlice string, outputSlice strin
 				output = nextRow[col].MergeInto(output)
 			}
 		}
-
 		dataset[i] = DataPoint{Input: input, Output: output}
 	}
 

--- a/neuralnetworks/layers/linearlayer.go
+++ b/neuralnetworks/layers/linearlayer.go
@@ -24,10 +24,10 @@ type LinearLayer struct {
 
 func (layer *LinearLayer) Initialize(numInputs int) {
 	layer.n_inputs = numInputs
+
 	if layer.weights != nil {
 		return
 	}
-
 	if layer.Outputs == 0 {
 		panic("You must specify how many Outputs a LinearLayer has!")
 	}


### PR DESCRIPTION
Now you can have a LSTM that doesn't take in a set number of inputs. Use the ConstantLengthInput flag if you wish to output a sequence to a non-variable-input layer, but only if you actually know it's constant length input. If not, use another LSTM that only outputs the final hidden state to coalesce the variable length sequence into one.